### PR TITLE
Add option for passing additional arguments to latexmk

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Options for LaTeX are:
 | linkThickness | 'very thick' | thickness of the link linkes in TikZ language |
 | tickCross | False | boolean for ticks to cross the axis or stay on one side |
 | preamble | '' | raw (!) string for the preamble of generated LaTeX documents |
+| latexmkOptions | [] | list of additional [arguments](https://man.cx/latexmk#heading4) to pass to latexmk |
 
 Input Specification
 -------------------

--- a/labella/tex.py
+++ b/labella/tex.py
@@ -53,10 +53,14 @@ def get_latex_fontdoc(text, fontsize='11pt', preamble=''):
 """.format(fontsize=fontsize, text=uni2tex(text), preamble=uni2tex(preamble))
     return tex
 
-def compile_latex(fname, tmpdirname, silent=True):
+def compile_latex(fname, tmpdirname, latexmk_options, silent=True):
     compiler = 'latexmk'
-    compiler_args = ['--pdf', '--outdir=' + tmpdirname,
-            '--interaction=nonstopmode', fname]
+    if latexmk_options:
+        compiler_args = latexmk_options +  ['--outdir=' + tmpdirname,
+                '--interaction=nonstopmode', fname]
+    else:
+        compiler_args = ['--pdf','--outdir=' + tmpdirname,
+                '--interaction=nonstopmode', fname]
     command = [compiler] + compiler_args
     try:
         output = subprocess.check_output(command, stderr=subprocess.STDOUT)
@@ -69,14 +73,14 @@ def compile_latex(fname, tmpdirname, silent=True):
         if not silent:
             print(output.decode())
 
-def get_latex_dims(tex, silent=True):
+def get_latex_dims(tex, latexmk_options, silent=True):
     with tempfile.TemporaryDirectory() as tmpdirname:
         basename = 'labella_text'
         fname = os.path.join(tmpdirname, basename + '.tex')
         with open(fname, 'w') as fid:
             fid.write(tex)
 
-        compile_latex(fname, tmpdirname, silent=silent)
+        compile_latex(fname, tmpdirname, latexmk_options, silent=silent)
 
         logname = os.path.join(tmpdirname, basename + '.log')
         with open(logname, 'r') as fid:
@@ -91,20 +95,22 @@ def get_latex_dims(tex, silent=True):
         height = line_height.strip().split(':')[-1].strip().rstrip('pt')
     return float(width), float(height)
 
-def build_latex_doc(tex, output_name=None, silent=True):
+def build_latex_doc(tex, latexmk_options, output_name=None, silent=True):
     with tempfile.TemporaryDirectory() as tmpdirname:
         basename = 'labella_text'
         fname = os.path.join(tmpdirname, basename + '.tex')
         with open(fname, 'w') as fid:
             fid.write(tex)
 
-        compile_latex(fname, tmpdirname, silent=silent)
+        compile_latex(fname, tmpdirname, latexmk_options, silent=silent)
 
         pdfname = os.path.join(tmpdirname, basename + '.pdf')
         if output_name:
             shutil.copy2(pdfname, output_name)
 
-def text_dimensions(text, fontsize='11pt', preamble='', silent=True):
+def text_dimensions(text, fontsize='11pt', preamble='', silent=True,
+                    latexmk_options=None):
     tex = get_latex_fontdoc(text, fontsize=fontsize, preamble=preamble)
-    width, height = get_latex_dims(tex, silent=silent)
+    width, height = get_latex_dims(tex, silent=silent, 
+                     latexmk_options=latexmk_options)
     return width, height

--- a/labella/timeline.py
+++ b/labella/timeline.py
@@ -55,7 +55,8 @@ DEFAULT_OPTIONS = {
             'tickThickness': 'thick',
             'linkThickness': 'very thick',
             'tickCross': False,
-            'preamble': ''
+            'preamble': '',
+            'latexmkOptions': []
             }
         }
 
@@ -66,7 +67,8 @@ def d3_functor(v):
 
 class Item(object):
     def __init__(self, time, width=DEFAULT_WIDTH, text=None, data=None,
-            output_mode='svg', tex_fontsize='11pt', tex_preamble=None):
+            output_mode='svg', tex_fontsize='11pt', 
+            tex_preamble=None, latexmk_options=None):
         self.time = time
         self.text = text
         self.width = width
@@ -74,6 +76,7 @@ class Item(object):
         self.output_mode = output_mode
         self.tex_fontsize = tex_fontsize
         self.tex_preamble = tex_preamble
+        self.latexmk_options = latexmk_options
         if self.width is None and self.text:
             self.width, self.height = self.get_text_dimensions()
         else:
@@ -86,7 +89,8 @@ class Item(object):
             height = 14.0
         else:
             width, height = text_dimensions(self.text,
-                    fontsize=self.tex_fontsize, preamble=self.tex_preamble)
+                    fontsize=self.tex_fontsize, preamble=self.tex_preamble,
+                    latexmk_options=self.latexmk_options)
             width = math.ceil(width) + 4
             height += 4
         return width, height
@@ -148,8 +152,9 @@ class Timeline(object):
                 width = d.get('width', DEFAULT_WIDTH)
             it = Item(time, width=width, text=text, data=d,
                     output_mode=output_mode,
-                    tex_fontsize=self.options['latex']['fontsize'], 
-                    tex_preamble=self.options['latex']['preamble'])
+                    tex_fontsize=self.options['latex']['fontsize'],
+                    tex_preamble=self.options['latex']['preamble'],
+                    latexmk_options=self.options['latex']['latexmkOptions'])
             items.append(it)
         return items
 
@@ -442,7 +447,8 @@ class TimelineTex(Timeline):
             fullname = os.path.realpath(filename)
             root = os.path.splitext(fullname)[0]
             output_name = root + ".pdf"
-            build_latex_doc(texlines, output_name=output_name)
+            build_latex_doc(texlines, self.options['latex']['latexmkOptions'],
+                output_name=output_name)
         return texlines
 
     def add_header(self, doc):


### PR DESCRIPTION
Needed some custom fonts that needed XeLaTeX to compile - this should let you pass such things on to `latexmk`.

Tried my best to adhere to your code style - but let me know if something needs tweaking!