### PR TITLE
fix TimelineSVG export

### DIFF
--- a/labella/timeline.py
+++ b/labella/timeline.py
@@ -330,7 +330,7 @@ class TimelineSVG(Timeline):
         self.add_labels(mainLayer)
         self.add_dots(mainLayer)
         svglines = ElementTree.tostring(doc)
-        if filename is None:
+        if filename is not None:
             with open(filename, "wb") as fid:
                 fid.write(svglines)
         return svglines


### PR DESCRIPTION
Thanks for labella. This is a minimal fix to TimelineSVG export method, that is not saving when provided with *filename* and I guess would fail otherwise.